### PR TITLE
Recomendação do uso da versão ods em vez da xlsx

### DIFF
--- a/checklists/checklist-10aspetos.html
+++ b/checklists/checklist-10aspetos.html
@@ -31,7 +31,7 @@
 	</div>
 	<div class="row">
 		<div class="col-sm">
-			<p><strong>Nota</strong>: Para recolha de evidências relativa a esta lista de verificação utilize o ficheiro excel: <a href="/kit-selo/checklists/sintese-10aspetos.xlsx">Recolha de evidências da Lista de verificação “10 aspetos críticos de acessibilidade funcional” (xlsx, 125KB)</a></p>
+			<p><strong>Nota</strong>: Para recolha de evidências relativa a esta lista de verificação utilize a folha de cálculo: <a href="/kit-selo/checklists/sintese-10aspetos.ods">Recolha de evidências da Lista de verificação “10 aspetos críticos de acessibilidade funcional” (ods, 56KB)</a></p>
 			<p>A <em lang="en">checklist</em> "10 aspetos críticos de acessibilidade funcional" é a lista de verificação a que se faz alusão no artigo 9.º, n.º 1, alínea b) do Decreto-Lei n.º 83/2018 e deve ser usada de acordo com a metodologia referenciada no diploma:</p>
 			<blockquote>
 				<ul>

--- a/checklists/checklist-conteudo.html
+++ b/checklists/checklist-conteudo.html
@@ -28,7 +28,7 @@
 	<div class="row">
 		<div class="col-sm">
 			<h1>Lista de verificação "Conteúdo"</h1>
-			<p><strong>Nota</strong>: Para recolha de evidências relativa a esta lista de verificação utilize o ficheiro excel: <a href="/kit-selo/checklists/sintese-conteudo.xlsx">Recolha de evidências da Lista de verificação “Conteúdo” (xlsx, 103KB)</a></p>
+			<p><strong>Nota</strong>: Para recolha de evidências relativa a esta lista de verificação utilize a folha de cálculo: <a href="/kit-selo/checklists/sintese-conteudo.ods">Recolha de evidências da Lista de verificação “Conteúdo” (ods, 53KB)</a></p>
 			<p>Requisitos a cumprir:</p>
 		</div>
 	</div>

--- a/checklists/checklist-transacao.html
+++ b/checklists/checklist-transacao.html
@@ -27,7 +27,7 @@
 	<div class="row">
 		<div class="col-sm">
 			<h1>Lista de verificação "Transação"</h1>
-			<p><strong>Nota</strong>: Para recolha de evidências relativa a esta lista de verificação utilize o ficheiro excel: <a href="/kit-selo/checklists/sintese-transacao.xlsx">Recolha de evidências da Lista de verificação “Transação” (xlsx, 87KB)</a></p>
+			<p><strong>Nota</strong>: Para recolha de evidências relativa a esta lista de verificação utilize a folha de cálculo: <a href="/kit-selo/checklists/sintese-transacao.ods">Recolha de evidências da Lista de verificação “Transação” (ods, 50KB)</a></p>
 			<p>Requisitos a cumprir:</p>
 		</div>
 	</div>		  	

--- a/checklists/en/checklist-10aspects.html
+++ b/checklists/en/checklist-10aspects.html
@@ -31,7 +31,7 @@
 	</div>
 	<div class="row">
 		<div class="col-sm">
-			<p><strong>Note</strong>: To collect evidence related to this checklist use the Excel file: <a href="/kit-selo/checklists/en/sintese-10aspetos.xlsx">Evidence collection from the Checklist “10 critical aspects of functional accessibility” (xlsx, 125KB)</a></p>
+			<p><strong>Note</strong>: To collect evidence related to this checklist use the spreadsheet file: <a href="/kit-selo/checklists/en/sintese-10aspetos.ods">Evidence collection from the Checklist “10 critical aspects of functional accessibility” (ods, 56KB)</a></p>
 			<p>The checklist "10 critical aspects of functional accessibility" is the checklist referred to in article 9(1)(b) of Decree-Law no. 83/2018 and must be used accordingly with the methodology referenced in the diploma:</p>
 			<blockquote>
 				<ul>

--- a/checklists/en/checklist-content.html
+++ b/checklists/en/checklist-content.html
@@ -28,7 +28,7 @@
 	<div class="row">
 		<div class="col-sm">
 			<h1>Checklist "Content"</h1>
-			<p><strong>Note</strong>: To collect evidence related to this checklist use the Excel file: <a href="/kit-selo/checklists/en/sintese-conteudo.xlsx">Recolha de evidências da Lista de verificação “Conteúdo” (xlsx, 103KB)</a></p>
+			<p><strong>Note</strong>: To collect evidence related to this checklist use the spreadsheet file: <a href="/kit-selo/checklists/en/sintese-conteudo.ods">Recolha de evidências da Lista de verificação “Conteúdo” (ods, 53KB)</a></p>
 			<p>Requirements to be met:</p>
 		</div>
 	</div>

--- a/checklists/en/checklist-transaction.html
+++ b/checklists/en/checklist-transaction.html
@@ -27,7 +27,7 @@
 	<div class="row">
 		<div class="col-sm">
 			<h1>Checklist "Transaction"</h1>
-			<p><strong>Note</strong>: To collect evidence related to this checklist use the Excel file: <a href="/kit-selo/checklists/en/sintese-transacao.xlsx">Recolha de evidências da Lista de verificação “Transação” (xlsx, 87KB)</a></p>
+			<p><strong>Note</strong>: To collect evidence related to this checklist use the spreadsheet file: <a href="/kit-selo/checklists/en/sintese-transacao.ods">Recolha de evidências da Lista de verificação “Transação” (ods, 50KB)</a></p>
 			<p>Requirements to be met:</p>
 		</div>
 	</div>		  	


### PR DESCRIPTION
Torna-se particularmente importante recomendar aqui o uso do ODS em vez do XLSX, visto que - como podemos ver nos exemplos práticos de quem já utilizou estes guias - quem usar os ficheiros no formato XLSX para fazer as suas checklists, depois vai acabar por publicá-las nesse mesmo formato, o que culmina na publicação de uma página de acessibilidade para o seu site com links para documentos em formato proprietário, em vez da publicação sob normas abertas, dando cumprimento ao Regulamento Nacional de Interoperabilidade Digital.

Com esta pequena mudança, espera-se que actualizações a sites existentes tão bem como sites futuros passem a cumprir o RNID.